### PR TITLE
Change 'Angular' label to 'AngularJS'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 <br>
 
 ## GoF design patterns (Language/Framework specifc) 
-- [Angular]
+- [AngularJS]
 	- [angularjs-in-patterns](https://github.com/mgechev/angularjs-in-patterns)
 - [Cat]
 	- [patterns for hoomans](https://github.com/mlnv/design-patterns-for-hoomans)


### PR DESCRIPTION
In Angular community it's clearly defined to distinguish "angular 1.x" and "angular 2+" as "AngularJS" and "Angular".
So I've updated your first entry in the list from "Angular" to "AngularJS" to prevent confusion as the link stands for AngularJS patterns.
Although you could argue that this section could embrace Angular patterns too (if there will be some articles on that topic), I'd suggest to separate the sections (AngularJS and Angular) as these are really different frameworks.

Anyway thank you for the great repo!
