### PR TITLE
Sync the TOC line for DevOps and Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Internet of things](#internet-of-things)
 - [Big Data](#big-data)
 - [Databases and storage](#databases)
-- [Docker and DevOps](#docker-and-devops)
+- [DevOps & containers](#devops--containers)
 - [Mobile](#mobile)
 - [Front End Development](#front-end-development)
 - [Security](#security)


### PR DESCRIPTION
Corrected the label, updated the link.