### PR TITLE
Add Dart/Flutter Design Patterns to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 	- [design-patterns](http://www.vincehuston.org/dp/)
 - Closure
 	- [design-patterns](https://arturoherrero.com/closure-design-patterns/)
+- Dart
+	- [Flutter Design Patterns](https://flutterdesignpatterns.com/) - OOP design patterns implemented in Dart and Flutter.
 - Go
 	- [design-patterns](https://github.com/tmrts/go-patterns)
 - Java


### PR DESCRIPTION
I would like to propose [Flutter Design Patterns](https://flutterdesignpatterns.com/) be added to the list. It's a prevalent learning resource in the Flutter community.

On the site, you could find all 23 GoF design patterns implemented in Dart while also allowing you to see them in action with interactive examples implemented in Flutter. In addition, each design pattern is explained in an extensive article on my blog.

Thanks and let me know what you think.